### PR TITLE
fixed missing assignment of loaded filter options

### DIFF
--- a/trunk/model/filters/Filter.cs
+++ b/trunk/model/filters/Filter.cs
@@ -284,7 +284,7 @@ namespace LogJoint
 
 		void LoadInternal(XElement e)
 		{
-			options.Load(e);	
+			options = options.Load(e);	
 			enabled = e.SafeIntValue("enabled", 1) != 0;
 			action = (FilterAction)e.SafeIntValue("action", (int)FilterAction.Include);
 			initialName = e.AttributeValue("initial-name", defaultValue: "");

--- a/trunk/model/filters/Filter.cs
+++ b/trunk/model/filters/Filter.cs
@@ -284,7 +284,7 @@ namespace LogJoint
 
 		void LoadInternal(XElement e)
 		{
-			options = options.Load(e);	
+			options = new Search.Options().Load(e);
 			enabled = e.SafeIntValue("enabled", 1) != 0;
 			action = (FilterAction)e.SafeIntValue("action", (int)FilterAction.Include);
 			initialName = e.AttributeValue("initial-name", defaultValue: "");


### PR DESCRIPTION
While importing filters, the filter options are parsed but not assigned to the local options object what leads to a null reference and results in an exception.